### PR TITLE
Fix ficha indicadores

### DIFF
--- a/core/dao/front_end.py
+++ b/core/dao/front_end.py
@@ -1,7 +1,9 @@
 from sqlalchemy.orm import Session
 from sqlalchemy import distinct
 from sqlalchemy import func
+from typing import List
 
+from ..schemas.transformacoes import parse_formula, get_var_names
 from ..models import front_end as models
 from ..models import basic as basicmodels
 from ..schemas import front_end as schemas
@@ -141,9 +143,18 @@ def get_ficha_indicador(db: Session, cd_indicador: int):
     indicador = basicdao.get_indicador(db, cd_indicador)
     if indicador is None:
         return None
+    
+    #colocando os resultados
     resultados = basicdao.resultados_indicador(db, cd_indicador)
-
     indicador.__setattr__('resultados', resultados)
+
+    #agora vamos ter que substituir as variaveis
+    #porque a tabela cross indicador_variavel nao está mais sendo utilizada
+    #para isso, vamos ter que parsear a formula do indicador
+    formula = indicador.dc_formula_indicador
+    formula = parse_formula(formula)
+    variaveis = get_var_names(formula, return_vars=True)
+    indicador.__setattr__('variaveis', variaveis)
 
     return indicador
 

--- a/core/models/basic.py
+++ b/core/models/basic.py
@@ -11,12 +11,14 @@ tema_indicador = Table(
     Column('cd_tipo_situacao', String)
 )
 
-variavel_indicador = Table(
-    "variavel_indicador",
-    metadata,
-    Column("cd_indicador", ForeignKey("indicador.cd_indicador")),
-    Column("cd_variavel", ForeignKey("variavel.cd_variavel")),
-)
+#tabela nao esta sendo usada no sistema (lixo no banco de dados)
+#relacao ocorre pelo string da formula de calculo
+#variavel_indicador = Table(
+#    "variavel_indicador",
+#    metadata,
+#    Column("cd_indicador", ForeignKey("indicador.cd_indicador")),
+#    Column("cd_variavel", ForeignKey("variavel.cd_variavel")),
+#)
 
 
 class Tema(Base):
@@ -70,7 +72,8 @@ class Indicador(Base):
     in_visibilidade = Column(Boolean)
     resultados = relationship("ResultadoIndicador")
     temas = relationship("Tema", secondary=tema_indicador)
-    variaveis = relationship("Variavel", secondary=variavel_indicador)
+    #desativando o relacionamento pois a tabela esta em desuso no sistema (lixo no banco)
+    #variaveis = relationship("Variavel", secondary=variavel_indicador)
 
     cd_tipo_situacao = Column(Integer)
 
@@ -143,7 +146,9 @@ class Variavel(Base):
     tx_fonte_variavel = Column(String)
     dc_nota_tecnica = Column(String)
     resultados = relationship("ResultadoVariavel", back_populates="variavel")
-    indicadores = relationship("Indicador", secondary=variavel_indicador, back_populates="variaveis")
+    #relacao entre indicador e variavel ocorre apenas pela formula de calculo
+    #tabela cross eh lixo no banco de dados
+    #indicadores = relationship("Indicador", secondary=variavel_indicador, back_populates="variaveis")
     cd_tipo_situacao = Column(Integer)
 
 class ResultadoVariavel(Base):

--- a/core/schemas/basic.py
+++ b/core/schemas/basic.py
@@ -41,8 +41,6 @@ class IndicadorReport(IndicadorBase):
     tx_fonte_indicador : Union[str, None] = None
     in_visibilidade : bool
     temas : List[TemaSimples] = []
-    variaveis: List[VariavelBase] = []
-
 
 class NivelRegiao(OrmBase):
 

--- a/core/schemas/transformacoes.py
+++ b/core/schemas/transformacoes.py
@@ -31,19 +31,23 @@ def parse_formula(formula):
             return ''
     return str(formula)
 
-def get_var_names(formula):
+def get_var_names(formula, return_vars=False):
 
     db = get_db_obj()
     formula_nova = []
+    vars = []
     for item in formula.split(' '):
         if item.lower().startswith('v'):
             var_obj = get_variavel(db, nm_resumido_variavel=item)
+            vars.append(var_obj)
             item = var_obj.nm_completo_variavel
             #envelopa em aspas simples
             item = f"'{item}'"
         formula_nova.append(item)
 
     db.close()
+    if return_vars:
+        return vars
 
     return ' '.join(formula_nova)
 


### PR DESCRIPTION
A tabela cross variavel_indicador na realidade é um lixo no banco de dados que não está sendo utilizado pelo sistema. A relação entre variaveis e indicadores se dá diretamente no string da formula de calculo do indicador. Aqui, removemos a relationship dos models e os referentes atributos "variaveis" e "indicadores" dos modelos para a variavel e o indicador. Além disso, na DAO para gerar a ficha do indicador, implementamos uma funcionalidade para buscar as variáveis por meio do parseamento da formula de calculo do indicador (usando os parsers que foram implementados anteriormente para colocar o nome por extenso das variaveis na formula de calculo).